### PR TITLE
Add test, fix return type, and include `infodict` in output if `full_output!=0`

### DIFF
--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -437,7 +437,15 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
 
     # if a == b, directly return 0 with error 0
     if a == b:
-        return [0, 0]
+        if full_output == 0:
+            return (0., 0.)
+        else:
+            return (0., 0., {"neval": 0, "last": 0,
+                             "alist": np.full(limit, np.nan, dtype=np.float64),
+                             "blist": np.full(limit, np.nan, dtype=np.float64),
+                             "rlist": np.zeros(limit, dtype=np.float64),
+                             "elist": np.zeros(limit, dtype=np.float64),
+                             "iord" : np.full(limit, np.nan, dtype=np.int32)})
 
     # check the limits of integration: \int_a^b, expect a < b
     flip, a, b = b < a, min(a, b), max(a, b)

--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -239,6 +239,14 @@ class TestQuad:
         err = max(res_1[1], res_2[1])
         assert_allclose(res_1[0], -res_2[0], atol=err)
 
+    def test_b_equals_a(self):
+        def f(x):
+            return x**(-0.5)
+
+        upper = lower = 0.
+        zero, err = quad(f, lower, upper)
+        assert_allclose((zero, err), (0., 0.), atol=err)
+
     def test_double_integral(self):
         # 8) Double Integral test
         def simpfunc(y, x):       # Note order of arguments.


### PR DESCRIPTION
Some fixes to address problems in currently open PR scipy/scipy#18147. 

#### Reference issue
scipy/scipy#18142

#### What does this implement/fix?
I created a `test_b_equals_a()` in `test_quadpack.py` to test the new functionality. I also changed the return type from a list to a tuple.

Perhaps most importantly, these changes make it so that an `infodict` will be returned as expected if the `full_output` parameter is non-zero. The `scipy.integrate.tplquad` refguide check was failing because it was expecting an output tuple of length 3 (i.e., with an `infodict`). This can be seen by examining the failing traceback:

```pytb
scipy.integrate.tplquad
-----------------------

File "build-install/lib/python3.10/site-packages/scipy/integrate/_quadpack_py.py", line 906, in tplquad
Failed example:
    integrate.tplquad(f, 0, 1, 0, lambda x: 1-2*x, 0, lambda x, y: 1-x-2*y)
Exception raised:
    Traceback (most recent call last):
      File "/path/to/conda/envs/scipy-dev/lib/python3.10/doctest.py", line 1350, in __run
        exec(compile(example.source, filename, "single",
      File "<doctest tplquad[5]>", line 1, in <module>
        integrate.tplquad(f, 0, 1, 0, lambda x: 1-2*x, 0, lambda x, y: 1-x-2*y)
      File "/path/to/my//scipy/integrate/_quadpack_py.py", line 945, in tplquad
        return nquad(func, ranges, args=args,
      File "/path/to/my//scipy/integrate/_quadpack_py.py", line 1212, in nquad
        res = _NQuad(func, ranges, opts, True).integrate(*args)
      File "/path/to/my//scipy/integrate/_quadpack_py.py", line 1278, in integrate
        quad_r = quad(f, low, high, args=args, full_output=self.full_output,
      File "/path/to/my//scipy/integrate/_quadpack_py.py", line 473, in quad
        retval = _quad(func, a, b, args, full_output, epsabs, epsrel, limit,
      File "/path/to/my//scipy/integrate/_quadpack_py.py", line 585, in _quad
        return _quadpack._qagse(func,a,b,args,full_output,epsabs,epsrel,limit)
      File "/path/to/my//scipy/integrate/_quadpack_py.py", line 1283, in integrate
        infodict = quad_r[2]
    IndexError: tuple index out of range


ERROR: refguide or doctests have errors
```
These changes should fix this error, but some details still warrant discussion, I think.

#### Additional information
Once you merge this into your own fork/branch, the open PR targeting the main SciPy repository should be automatically updated, and we can continue the discussion there.